### PR TITLE
Add API status indicator to footer

### DIFF
--- a/src/lib/components/ApiStatus.svelte
+++ b/src/lib/components/ApiStatus.svelte
@@ -1,0 +1,71 @@
+<script>
+	import { onMount } from 'svelte';
+
+	/**
+	 * @typedef {Object} StatusSummary
+	 * @property {string} status
+	 * @property {number} apiLatencyMs
+	 * @property {number} dataLatencyMs
+	 * @property {string} checkedAt
+	 * @property {string} statusColor
+	 * @property {string} statusLabel
+	 */
+
+	/** @type {StatusSummary | null} */
+	let summary = $state(null);
+	let hover = $state(false);
+
+	function toggleHover() {
+		hover = !hover;
+	}
+
+	onMount(async () => {
+		try {
+			const res = await fetch('https://status.openelectricity.org.au/api/summary');
+			if (res.ok) {
+				summary = await res.json();
+			}
+		} catch {
+			// Silently fail — component renders nothing on error
+		}
+	});
+</script>
+
+{#if summary}
+	<a
+		href="https://status.openelectricity.org.au"
+		target="_blank"
+		rel="noopener noreferrer"
+		class="flex items-center gap-3 font-bold font-space transition-all text-dark-grey hover:text-red hover:no-underline"
+		onmouseenter={toggleHover}
+		onmouseleave={toggleHover}
+	>
+		<span
+			class="inline-block size-2.5 shrink-0 rounded-full"
+			style="background-color: {summary.statusColor}"
+		></span>
+		API Status
+		<svg
+			class="transition-all"
+			class:translate-x-1={hover}
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<circle
+				cx="10"
+				cy="10"
+				r="9.5"
+				fill="white"
+				class={`transition-all ${hover ? 'stroke-red' : 'stroke-black'}`}
+			/>
+			<path
+				d="M7.99854 14L12.3319 9.66671L7.99854 5.33337"
+				stroke-width="1.5"
+				class={`transition-all ${hover ? 'stroke-red' : 'stroke-black'}`}
+			/>
+		</svg>
+	</a>
+{/if}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { version } from '$app/environment';
 	import { ScrollText } from '@lucide/svelte';
+	import ApiStatus from './ApiStatus.svelte';
 	import SectionLink from './SectionLink.svelte';
 	import SignUpForm from './SignUpForm.svelte';
 </script>
@@ -64,6 +65,7 @@
 						target="_blank"
 						title="Documentation"
 					/>
+					<ApiStatus />
 				</p>
 
 				<h5 class="mt-12">Transparency & Accountability</h5>


### PR DESCRIPTION
## Summary

- Adds a new `ApiStatus` component that fetches live operational status from the OpenElectricity status page API on mount
- Displays a colour-coded status dot and "API Status" link in the footer's For Developers section, alongside the existing Platform and Documentation links
- Matches the existing `SectionLink` style (font, hover animation, chevron icon) and silently renders nothing if the fetch fails