### PR TITLE
Show battery discharging in scenarios + homepage

### DIFF
--- a/src/lib/components/charts/v2/MiniCharts.svelte
+++ b/src/lib/components/charts/v2/MiniCharts.svelte
@@ -30,6 +30,7 @@
 	 * @property {any} [xTicks]
 	 * @property {(value: any, timeZone?: string) => string} [formatTickX]
 	 * @property {(value: number) => string} [formatTickY]
+	 * @property {(value: number, key: string) => string} [formatValue] - Optional per-series formatter for the big-number headline only; overrides formatTickY for that value (e.g. extra decimals for a small series). Falls back to formatTickY when omitted.
 	 * @property {number | undefined} [overlayStart]
 	 * @property {any[]} [bgShadingData]
 	 * @property {string} [bgShadingFill]
@@ -70,6 +71,7 @@
 		xTicks,
 		formatTickX,
 		formatTickY,
+		formatValue,
 		overlayStart,
 		bgShadingData = [],
 		bgShadingFill = '',
@@ -285,6 +287,14 @@
 		{@const title = seriesLabels[key]}
 		{@const displayValue = getDisplayValue(store, key)}
 		{@const displayTime = getDisplayTime(store)}
+		{@const headlineValue =
+			displayValue == null
+				? '—'
+				: formatValue
+					? formatValue(displayValue, key)
+					: formatTickY
+						? formatTickY(displayValue)
+						: '—'}
 
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<section
@@ -319,7 +329,7 @@
 				{#if showCardSummary}
 					<h3 class="leading-sm h-14 mt-4 mb-0">
 						{#if displayTime}
-							{displayValue != null && formatTickY ? formatTickY(displayValue) : '—'}
+							{headlineValue}
 							<small class="block text-xs text-mid-grey font-light">{displayUnit}</small>
 						{/if}
 					</h3>

--- a/src/lib/components/info-graphics/scenarios-explorer/groups/homepage-preview.js
+++ b/src/lib/components/info-graphics/scenarios-explorer/groups/homepage-preview.js
@@ -62,7 +62,7 @@ export const order = [
 	// 'distillate',
 	'gas',
 
-	// 'battery_discharging',
+	'battery_discharging',
 	'hydro',
 
 	'wind',

--- a/src/lib/components/info-graphics/scenarios-explorer/homepage/DetailedBreakdown.svelte
+++ b/src/lib/components/info-graphics/scenarios-explorer/homepage/DetailedBreakdown.svelte
@@ -1,5 +1,7 @@
 <script>
 	import MiniCharts from '$lib/components/charts/v2/MiniCharts.svelte';
+	import { convert } from '$lib/utils/si-units';
+	import { getNumberFormat } from '$lib/utils/formatters';
 	import { withScenarioLabels } from '../../../../../routes/(main)/scenarios/page-data-options/models';
 
 	/**
@@ -22,7 +24,7 @@
 
 	let gridColClass = $derived(
 		selectedGroup === 'homepage_preview'
-			? 'grid-cols-2 md:grid-cols-6'
+			? 'grid-cols-2 md:grid-cols-7'
 			: 'grid-cols-2'
 	);
 
@@ -35,6 +37,22 @@
 
 	let bgShadingData = $derived(chart.bgShadingData);
 	let bgShadingFill = $derived(chart.bgShadingFill);
+
+	// Battery (discharging) is tiny historically, so it rounds to "0 TWh" at the
+	// default integer precision. Give just that tile's headline one decimal place;
+	// every other tile keeps the chart's standard formatter.
+	/**
+	 * @param {number} value
+	 * @param {string} key
+	 */
+	function formatHeadlineValue(value, key) {
+		const label = chart.seriesLabels[key] || '';
+		if (!label.toLowerCase().includes('battery')) {
+			return chart.convertAndFormatValue(value);
+		}
+		const converted = convert(chart.chartOptions.prefix, chart.chartOptions.displayPrefix, value);
+		return isNaN(converted) ? '—' : getNumberFormat(1).format(converted);
+	}
 </script>
 
 {#if chart.seriesData.length > 0}
@@ -49,6 +67,7 @@
 			xTicks={chart.xTicks}
 			formatTickX={chart.formatTickX}
 			formatTickY={chart.convertAndFormatValue}
+			formatValue={formatHeadlineValue}
 			overlayStart={overlayStartValue}
 			shadingData={bgShadingData}
 			shadingFill={bgShadingFill}
@@ -56,7 +75,7 @@
 			focusTime={chart.focusTime}
 			{gridColClass}
 			gridGapClass="gap-0"
-			sectionBorderClass="p-8 border-r border-mid-warm-grey md:last:border-r-0 [&:nth-child(-n+4)]:border-b md:[&:nth-child(-n+4)]:border-b-0"
+			sectionBorderClass="p-8 border-r border-mid-warm-grey last:border-r-0 [&:nth-child(-n+6)]:border-b md:[&:nth-child(-n+6)]:border-b-0"
 			showIcon={true}
 			{onhover}
 			{onhoverend}
@@ -64,7 +83,7 @@
 	</div>
 {:else}
 	<div class="border-t border-b md:border-x border-mid-warm-grey grid {gridColClass} gap-0">
-		{#each { length: 6 } as _, i (i)}
+		{#each { length: 7 } as _, i (i)}
 			<div class="p-8 border-r border-mid-warm-grey animate-pulse">
 				<div class="h-4 w-2/3 bg-warm-grey rounded mb-4"></div>
 				<div class="h-8 w-1/3 bg-warm-grey rounded mb-6"></div>

--- a/src/routes/(main)/scenarios/components/TableHeader.svelte
+++ b/src/routes/(main)/scenarios/components/TableHeader.svelte
@@ -20,7 +20,7 @@
 		{#if showCheckbox}
 			<Checkbox
 				name="includeBatteryAndLoads"
-				label="Include Storage and Loads"
+				label="Include Loads"
 				checked={includeBatteryAndLoads}
 				{onchange}
 			/>

--- a/src/routes/(main)/scenarios/page-data-options/exclude-battery-and-loads.js
+++ b/src/routes/(main)/scenarios/page-data-options/exclude-battery-and-loads.js
@@ -1,14 +1,12 @@
-const batteryAndLoads = [
-	'battery_discharging',
-	'battery_VPP_discharging',
-	'battery_distributed_discharging',
+// Loads (and storage *charging*) hidden unless "Include Loads" is on.
+// Battery (discharging) is intentionally NOT listed here — it's a generation
+// source and always shown in the technology breakdown.
+const loads = [
 	'battery_charging',
 	'battery_VPP_charging',
 	'battery_distributed_charging',
-	'battery',
 	'exports',
 	'pumps',
-	'storage_discharging',
 	'storage_charging'
 ];
 
@@ -18,7 +16,7 @@ const batteryAndLoads = [
  * @returns
  */
 export default function (fuelTechs) {
-	const filterKeys = Object.keys(fuelTechs).filter((key) => !batteryAndLoads.includes(key));
+	const filterKeys = Object.keys(fuelTechs).filter((key) => !loads.includes(key));
 
 	return filterKeys.reduce((/** @type Object.<FuelTechCode, FuelTechCode[]> */ acc, key) => {
 		acc[key] = fuelTechs[key];

--- a/src/routes/(main)/scenarios/page-data-options/exclude-battery-and-loads.test.js
+++ b/src/routes/(main)/scenarios/page-data-options/exclude-battery-and-loads.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import excludeBatteryAndLoads from './exclude-battery-and-loads.js';
+
+describe('excludeBatteryAndLoads', () => {
+	// Mirrors the group-key structure of the simple/detailed scenario groups.
+	const groupKeys = {
+		storage_charging: ['battery_charging', 'pumps'],
+		storage_discharging: ['battery', 'battery_discharging'],
+		exports: ['exports'],
+		coal: ['coal_black', 'coal_brown'],
+		gas: ['gas_ccgt'],
+		wind: ['wind'],
+		solar_utility: ['solar_utility']
+	};
+
+	const result = excludeBatteryAndLoads(groupKeys);
+
+	it('keeps battery discharging — it is generation and always shown', () => {
+		expect(result).toHaveProperty('storage_discharging');
+		expect(result.storage_discharging).toEqual(groupKeys.storage_discharging);
+	});
+
+	it('removes storage charging and exports (loads gated by the toggle)', () => {
+		expect(result).not.toHaveProperty('storage_charging');
+		expect(result).not.toHaveProperty('exports');
+	});
+
+	it('keeps all non-load generation sources', () => {
+		expect(result).toHaveProperty('coal');
+		expect(result).toHaveProperty('gas');
+		expect(result).toHaveProperty('wind');
+		expect(result).toHaveProperty('solar_utility');
+	});
+
+	it('does not mutate the input', () => {
+		expect(groupKeys).toHaveProperty('storage_charging');
+		expect(groupKeys).toHaveProperty('exports');
+	});
+});

--- a/src/routes/(main)/scenarios/page-data-options/groups-technology.test.js
+++ b/src/routes/(main)/scenarios/page-data-options/groups-technology.test.js
@@ -34,10 +34,11 @@ describe('groups-technology', () => {
 			expect(keys).toContain('hydro');
 		});
 
-		it('homepage_preview order has 6 entries for the grid layout', () => {
+		it('homepage_preview order has 7 entries (incl. battery discharging) for the grid layout', () => {
 			expect(orderMap['homepage_preview']).toEqual([
 				'coal',
 				'gas',
+				'battery_discharging',
 				'hydro',
 				'wind',
 				'solar_utility',

--- a/src/routes/(main)/scenarios/page-data-options/process-technology.test.js
+++ b/src/routes/(main)/scenarios/page-data-options/process-technology.test.js
@@ -83,6 +83,31 @@ describe('processTechnology', () => {
 			expect(result).toHaveProperty('allowedPrefixes');
 		});
 
+		it('shows battery discharging but not charging when loads are excluded', () => {
+			const projection = [
+				makeProjectionStats({ fuelTech: 'wind', data: [200, 220, 240] }),
+				makeProjectionStats({ fuelTech: 'battery_discharging', data: [10, 12, 14] }),
+				makeProjectionStats({ fuelTech: 'battery_charging', data: [8, 9, 10] })
+			];
+			const history = [
+				makeHistoryStats({ fuelTech: 'wind', data: monthlyData(100) }),
+				makeHistoryStats({ fuelTech: 'battery_discharging', data: monthlyData(5) }),
+				makeHistoryStats({ fuelTech: 'battery_charging', data: monthlyData(4) })
+			];
+
+			const result = processTechnology.generation({
+				projection,
+				history,
+				group: 'simple',
+				colourReducer,
+				includeBatteryAndLoads: false
+			});
+
+			const labels = Object.values(result.seriesLabels);
+			expect(labels).toContain('Storage (Discharging)');
+			expect(labels).not.toContain('Storage (Charging)');
+		});
+
 		it('returns displayPrefix T and allowedPrefixes G/T for energy', () => {
 			const projection = [
 				makeProjectionStats({ fuelTech: 'solar_utility', data: [100, 110, 120] })


### PR DESCRIPTION
Battery (discharging) is a generation source but was hidden behind the "Include Storage and Loads" toggle in the scenarios technology view, and absent from the homepage preview entirely. This surfaces it in both places.

## Scenarios technology view

- Drop the discharging fuel techs from `exclude-battery-and-loads.js` so battery (discharging) is **always** shown in the technology breakdown; only genuine loads (battery charging, pumps, exports) stay gated.
- Relabel the toggle from **"Include Storage and Loads"** → **"Include Loads"**.
- The scenario/region **aggregate** views are intentionally unchanged — their `sources_without_battery` grouping omits battery to avoid double-counting the charge/discharge round-trip in net generation.

## Homepage preview

- Add a **Battery (Discharging)** tile by including it in the `homepage_preview` group order. It now appears as a band in the main chart and as its own mini chart, across both the historical and projected periods (history reports `battery_discharging`; projections add the granular VPP/distributed variants, all mapped to the same bucket).
- Bump the desktop grid to 7 columns so the tiles stay in **one row** on desktop, keeping the 2-column wrap on mobile.
- Battery discharge is tiny historically and rounds to `0 TWh`, so give **just that tile's** headline one decimal place, via a new optional per-series `formatValue` prop on `MiniCharts` (every other tile keeps the integer formatter).

## Tests

- New `exclude-battery-and-loads.test.js` (discharging kept, loads removed) and a `process-technology` integration test (battery discharging shows, charging doesn't, when loads are off).
- Updated the `homepage_preview` order assertion to the new 7-entry layout.
- Full suite: 1485 passing.