### PR TITLE
facility page schema.org structured data

### DIFF
--- a/.claude/skills/fueltech-add/SKILL.md
+++ b/.claude/skills/fueltech-add/SKILL.md
@@ -40,7 +40,11 @@ For each grouping file (`simple.js`, `detailed.js`, `renewables-fossils.js`, `si
 
 When in doubt, open the existing file and match the convention for its closest sibling (e.g. adding `wind_floating` → group wherever `wind_offshore` appears).
 
-### 4. Icon (optional)
+### 4. `src/lib/seo/facility-jsonld.js` (optional but check)
+
+`FUELTECH_WIKIDATA_CLASS` maps fuel-tech codes to Wikidata power-station classes for facility-page JSON-LD. An unmapped code silently falls back to the generic "power station" entity — fine for loads/aggregates, but a new generation fuel-tech should get an entry. **Verify the QID against wikidata.org before adding** (fetch the entity and check its English label); plausible-looking QIDs frequently resolve to unrelated entities.
+
+### 5. Icon (optional)
 
 If an SVG icon exists for the new fuel-tech, drop it under `src/lib/icons/fuel-techs/`. Follow the naming convention of existing files (e.g. `WindSm.svelte`, `SolarUtilitySm.svelte`). The user typically provides the SVG — don't invent one.
 
@@ -60,5 +64,6 @@ After all edits:
 
 - `src/lib/theme/openelectricity.js` — `fuelTechColourMap`.
 - `src/lib/fuel_techs.js` — `fuelTechNameMap`, `loadFuelTechs`, `isLoad`.
+- `src/lib/seo/facility-jsonld.js` — `FUELTECH_WIKIDATA_CLASS` for facility JSON-LD.
 - `src/lib/fuel-tech-groups/simple.js` — canonical grouping shape (`fuelTechMap`, `order`, `labels`, `fuelTechNameReducer`).
 - `src/lib/icons/fuel-techs/` — per-fueltech SVG icons.

--- a/src/lib/components/Meta.svelte
+++ b/src/lib/components/Meta.svelte
@@ -14,6 +14,7 @@
 	 * @property {string} [siteTitle]
 	 * @property {boolean} [useSuffix]
 	 * @property {boolean | string} [canonical] - false suppresses the canonical link (e.g. draft/preview routes); a string overrides the URL
+	 * @property {string | null} [jsonLd] - schema.org JSON-LD, pre-escaped with $lib/seo/jsonld.js jsonLdToString so it's safe for the {@html} sink
 	 */
 
 	/** @type {Props} */
@@ -29,7 +30,8 @@
 		domain = 'https://openelectricity.org.au',
 		siteTitle = 'Open Electricity',
 		useSuffix = true,
-		canonical = true
+		canonical = true,
+		jsonLd = null
 	} = $props();
 	let titleWithSuffix = $derived(
 		siteTitle === title ? title : (title ? title + ' | ' : '') + siteTitle
@@ -39,9 +41,19 @@
 	// og:image should be an absolute URL — prefix the domain for root-relative paths.
 	let imageUrl = $derived(image && !/^https?:\/\//.test(image) ? `${domain}${image}` : image);
 	let canonicalUrl = $derived(canonical === true ? fullURI : canonical || null);
+	// The script-tag delimiters are assembled from pieces — Svelte's parser
+	// treats a literal "<script" anywhere in the file, even inside a string,
+	// as a component script block. Safe as {@html}: jsonLd is pre-escaped
+	// (jsonLdToString escapes "<") so content can never close the tag early.
+	let jsonLdTag = $derived(
+		jsonLd ? `${'<'}script type="application/ld+json">${jsonLd}${'<'}/script>` : null
+	);
 </script>
 
 <svelte:head>
+	{#if jsonLdTag}
+		{@html jsonLdTag}
+	{/if}
 	<meta property="og:type" content={type} />
 	<meta property="og:site_name" content={siteTitle} />
 	<meta property="og:url" content={fullURI} />

--- a/src/lib/components/Meta.svelte
+++ b/src/lib/components/Meta.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from '$app/stores';
+	import { jsonLdToString } from '$lib/seo/jsonld.js';
 	/**
 	 * @typedef {Object} Props
 	 * @property {string} [type] - or article, or music.album etc. See https://ogp.me/#types
@@ -14,7 +15,7 @@
 	 * @property {string} [siteTitle]
 	 * @property {boolean} [useSuffix]
 	 * @property {boolean | string} [canonical] - false suppresses the canonical link (e.g. draft/preview routes); a string overrides the URL
-	 * @property {string | null} [jsonLd] - schema.org JSON-LD, pre-escaped with $lib/seo/jsonld.js jsonLdToString so it's safe for the {@html} sink
+	 * @property {Record<string, any> | null} [jsonLd] - schema.org JSON-LD object; stringified and escaped here (the single {@html} sink) so callers never handle escaping
 	 */
 
 	/** @type {Props} */
@@ -41,17 +42,18 @@
 	// og:image should be an absolute URL — prefix the domain for root-relative paths.
 	let imageUrl = $derived(image && !/^https?:\/\//.test(image) ? `${domain}${image}` : image);
 	let canonicalUrl = $derived(canonical === true ? fullURI : canonical || null);
-	// The script-tag delimiters are assembled from pieces — Svelte's parser
-	// treats a literal "<script" anywhere in the file, even inside a string,
-	// as a component script block. Safe as {@html}: jsonLd is pre-escaped
-	// (jsonLdToString escapes "<") so content can never close the tag early.
+	// A literal "</script" anywhere in this file — even inside a string — ends
+	// the component script block early, so the closing delimiter is assembled
+	// from pieces. Safe as {@html}: jsonLdToString escapes "<" so content can
+	// never close the tag.
 	let jsonLdTag = $derived(
-		jsonLd ? `${'<'}script type="application/ld+json">${jsonLd}${'<'}/script>` : null
+		jsonLd ? `<script type="application/ld+json">${jsonLdToString(jsonLd)}${'<'}/script>` : null
 	);
 </script>
 
 <svelte:head>
 	{#if jsonLdTag}
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -- jsonLdToString escapes "<" so content cannot break out of the script tag -->
 		{@html jsonLdTag}
 	{/if}
 	<meta property="og:type" content={type} />

--- a/src/lib/seo/facility-jsonld.js
+++ b/src/lib/seo/facility-jsonld.js
@@ -1,0 +1,175 @@
+/**
+ * schema.org JSON-LD for facility pages.
+ *
+ * schema.org has no power-station type (long-standing gap), so facilities are
+ * described as a `Place` with `additionalType` pointing at the matching
+ * Wikidata class — the standard workaround for entity disambiguation.
+ * Capacity and fuel technology ride along as `PropertyValue` entries since no
+ * native schema.org properties exist for them. None of this earns rich
+ * results; the value is knowledge-graph association (geo + sameAs links to
+ * Wikipedia/Wikidata/OSM).
+ */
+
+import { fuelTechNameMap } from '$lib/fuel_techs.js';
+import { regionsWithShortLabels } from '$lib/regions.js';
+import { EXTERNAL_LINKS } from '$lib/constants/external-links.js';
+import { sumUnitCapacities } from '$lib/utils/capacity';
+import { primaryFuelTech } from '$lib/utils/fueltech-display';
+import { jsonLdToString } from './jsonld.js';
+
+// Entity URI, deliberately not EXTERNAL_LINKS.wikidata's /wiki/ page URL —
+// sameAs/additionalType want the canonical entity form.
+export const WIKIDATA_ENTITY = 'http://www.wikidata.org/entity/';
+
+/**
+ * Wikidata classes for power-station types, keyed by OE fuel tech. QIDs
+ * verified against wikidata.org labels (2026-08): don't add entries without
+ * checking — several "obvious" QIDs resolve to unrelated entities.
+ * (New fueltech ids fall back to the generic class — see the fueltech-add
+ * skill checklist.)
+ * @type {Record<string, string>}
+ */
+const FUELTECH_WIKIDATA_CLASS = {
+	coal_black: 'Q6558431', // coal-fired power station
+	coal_brown: 'Q6558431',
+	coal: 'Q6558431',
+	gas_ccgt: 'Q2944640', // gas-fired power station
+	gas_ccgt_ccs: 'Q2944640',
+	gas_ocgt: 'Q2944640',
+	gas_recip: 'Q2944640',
+	gas_steam: 'Q2944640',
+	gas_wcmg: 'Q2944640',
+	gas_hydrogen: 'Q2944640',
+	gas: 'Q2944640',
+	hydro: 'Q15911738', // hydroelectric power station
+	pumps: 'Q339353', // pumped-storage power station
+	wind: 'Q194356', // wind farm
+	wind_offshore: 'Q194356',
+	solar_utility: 'Q1003207', // photovoltaic power station
+	solar: 'Q1003207',
+	solar_thermal: 'Q285927', // thermal solar power station
+	battery: 'Q810924', // battery storage power station
+	battery_charging: 'Q810924',
+	battery_discharging: 'Q810924',
+	bioenergy_biomass: 'Q55364050', // biomass-fired power station
+	nuclear: 'Q134447' // nuclear power plant
+};
+
+const GENERIC_POWER_STATION = 'Q159719'; // power station
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {string | null}
+ */
+function httpUrlOrNull(value) {
+	return typeof value === 'string' && /^https?:\/\//.test(value.trim()) ? value.trim() : null;
+}
+
+/**
+ * Build the JSON-LD graph (Place + BreadcrumbList) for a facility page.
+ * Returns null when there's no facility to describe.
+ *
+ * @param {Object} args
+ * @param {any} args.facility - OE API facility record
+ * @param {any} args.sanityFacility - Sanity profile (may be null)
+ * @param {string} args.url - absolute canonical page URL
+ * @param {string} args.image - absolute OG image URL
+ * @param {string} args.description
+ * @returns {object | null}
+ */
+export function buildFacilityJsonLd({ facility, sanityFacility, url, image, description }) {
+	if (!facility?.name) return null;
+
+	const units = Array.isArray(facility.units) ? facility.units : [];
+	const primaryFt = primaryFuelTech(units);
+	const wikidataClass = (primaryFt && FUELTECH_WIKIDATA_CLASS[primaryFt]) || GENERIC_POWER_STATION;
+
+	/** @type {Record<string, any>} */
+	const place = {
+		'@type': 'Place',
+		'@id': `${url}#place`,
+		additionalType: `${WIKIDATA_ENTITY}${wikidataClass}`,
+		name: facility.name,
+		url
+	};
+
+	if (description) place.description = description;
+	if (image) place.image = image;
+
+	// First location with usable coordinates — a malformed OE location (e.g.
+	// null lat/lng) must not shadow a valid Sanity one.
+	const location = [facility.location, sanityFacility?.location].find(
+		(l) => Number.isFinite(l?.lat) && Number.isFinite(l?.lng)
+	);
+	if (location) {
+		place.geo = {
+			'@type': 'GeoCoordinates',
+			latitude: location.lat,
+			longitude: location.lng
+		};
+	}
+
+	place.address = { '@type': 'PostalAddress', addressCountry: 'AU' };
+	const state = regionsWithShortLabels[(facility.network_region || '').toLowerCase()];
+	if (state) place.address.addressRegion = state;
+
+	const wikidataId = (sanityFacility?.wikidata_id ?? '').trim?.() || '';
+	const osmWayId = sanityFacility?.osm_way_id;
+	const sameAs = [
+		httpUrlOrNull(sanityFacility?.wikipedia),
+		/^Q\d+$/.test(wikidataId) ? `${WIKIDATA_ENTITY}${wikidataId}` : null,
+		osmWayId ? `${EXTERNAL_LINKS.openStreetMap.baseUrl}/way/${osmWayId}` : null,
+		httpUrlOrNull(sanityFacility?.website)
+	].filter(Boolean);
+	if (sameAs.length) place.sameAs = sameAs;
+
+	const additionalProperty = [];
+	const capacity = sumUnitCapacities(units);
+	if (capacity > 0) {
+		additionalProperty.push({
+			'@type': 'PropertyValue',
+			name: 'Nameplate capacity',
+			value: Math.round(capacity * 10) / 10,
+			unitText: 'MW'
+		});
+	}
+	const fuelTechLabels = [
+		...new Set(
+			units.map((/** @type {any} */ u) => fuelTechNameMap[u?.fueltech_id] ?? null).filter(Boolean)
+		)
+	];
+	if (fuelTechLabels.length) {
+		additionalProperty.push({
+			'@type': 'PropertyValue',
+			name: 'Fuel technology',
+			value: fuelTechLabels.join(', ')
+		});
+	}
+	if (additionalProperty.length) place.additionalProperty = additionalProperty;
+
+	const origin = new URL(url).origin;
+	const breadcrumb = {
+		'@type': 'BreadcrumbList',
+		itemListElement: [
+			{ '@type': 'ListItem', position: 1, name: 'Open Electricity', item: origin },
+			{ '@type': 'ListItem', position: 2, name: 'Facilities', item: `${origin}/facilities` },
+			{ '@type': 'ListItem', position: 3, name: facility.name, item: url }
+		]
+	};
+
+	return {
+		'@context': 'https://schema.org',
+		'@graph': [place, breadcrumb]
+	};
+}
+
+/**
+ * Pre-escaped JSON-LD string for a facility page, ready for Meta.svelte's
+ * `jsonLd` prop; null when there's nothing to describe.
+ * @param {Parameters<typeof buildFacilityJsonLd>[0]} args
+ * @returns {string | null}
+ */
+export function facilityJsonLdString(args) {
+	const jsonLd = buildFacilityJsonLd(args);
+	return jsonLd ? jsonLdToString(jsonLd) : null;
+}

--- a/src/lib/seo/facility-jsonld.js
+++ b/src/lib/seo/facility-jsonld.js
@@ -15,7 +15,6 @@ import { regionsWithShortLabels } from '$lib/regions.js';
 import { EXTERNAL_LINKS } from '$lib/constants/external-links.js';
 import { sumUnitCapacities } from '$lib/utils/capacity';
 import { primaryFuelTech } from '$lib/utils/fueltech-display';
-import { jsonLdToString } from './jsonld.js';
 
 // Entity URI, deliberately not EXTERNAL_LINKS.wikidata's /wiki/ page URL —
 // sameAs/additionalType want the canonical entity form.
@@ -66,7 +65,8 @@ function httpUrlOrNull(value) {
 }
 
 /**
- * Build the JSON-LD graph (Place + BreadcrumbList) for a facility page.
+ * Build the JSON-LD graph (Place + BreadcrumbList) for a facility page, for
+ * Meta.svelte's `jsonLd` prop (which handles stringifying and escaping).
  * Returns null when there's no facility to describe.
  *
  * @param {Object} args
@@ -75,7 +75,7 @@ function httpUrlOrNull(value) {
  * @param {string} args.url - absolute canonical page URL
  * @param {string} args.image - absolute OG image URL
  * @param {string} args.description
- * @returns {object | null}
+ * @returns {Record<string, any> | null}
  */
 export function buildFacilityJsonLd({ facility, sanityFacility, url, image, description }) {
 	if (!facility?.name) return null;
@@ -161,15 +161,4 @@ export function buildFacilityJsonLd({ facility, sanityFacility, url, image, desc
 		'@context': 'https://schema.org',
 		'@graph': [place, breadcrumb]
 	};
-}
-
-/**
- * Pre-escaped JSON-LD string for a facility page, ready for Meta.svelte's
- * `jsonLd` prop; null when there's nothing to describe.
- * @param {Parameters<typeof buildFacilityJsonLd>[0]} args
- * @returns {string | null}
- */
-export function facilityJsonLdString(args) {
-	const jsonLd = buildFacilityJsonLd(args);
-	return jsonLd ? jsonLdToString(jsonLd) : null;
 }

--- a/src/lib/seo/facility-jsonld.test.js
+++ b/src/lib/seo/facility-jsonld.test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { WIKIDATA_ENTITY, buildFacilityJsonLd } from './facility-jsonld.js';
-import { jsonLdToString } from './jsonld.js';
 
 const URL = 'https://openelectricity.org.au/facility/BAYSW';
 const IMAGE = 'https://openelectricity.org.au/og/facility/BAYSW.jpg';
@@ -171,13 +170,5 @@ describe('buildFacilityJsonLd', () => {
 			name: 'Bayswater',
 			item: URL
 		});
-	});
-});
-
-describe('jsonLdToString', () => {
-	it('escapes < so content cannot close the script tag', () => {
-		const out = jsonLdToString({ description: 'bad </script><script>alert(1)</script>' });
-		expect(out).not.toContain('</script>');
-		expect(out).toContain('\\u003c/script>');
 	});
 });

--- a/src/lib/seo/facility-jsonld.test.js
+++ b/src/lib/seo/facility-jsonld.test.js
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { WIKIDATA_ENTITY, buildFacilityJsonLd } from './facility-jsonld.js';
+import { jsonLdToString } from './jsonld.js';
+
+const URL = 'https://openelectricity.org.au/facility/BAYSW';
+const IMAGE = 'https://openelectricity.org.au/og/facility/BAYSW.jpg';
+
+const facility = {
+	code: 'BAYSW',
+	name: 'Bayswater',
+	network_id: 'NEM',
+	network_region: 'NSW1',
+	location: { lat: -32.39, lng: 150.95 },
+	units: Array.from({ length: 4 }, () => ({ fueltech_id: 'coal_black', capacity_registered: 660 }))
+};
+
+const sanityFacility = {
+	wikipedia: 'https://en.wikipedia.org/wiki/Bayswater_Power_Station',
+	wikidata_id: 'Q808522',
+	osm_way_id: '104204275',
+	website: 'https://www.agl.com.au/'
+};
+
+function build(overrides = {}) {
+	return buildFacilityJsonLd({
+		facility,
+		sanityFacility,
+		url: URL,
+		image: IMAGE,
+		description: 'A power station.',
+		...overrides
+	});
+}
+
+/**
+ * @param {any} jsonLd
+ * @param {string} type
+ */
+function nodeOf(jsonLd, type) {
+	return jsonLd['@graph'].find((/** @type {any} */ n) => n['@type'] === type);
+}
+
+describe('buildFacilityJsonLd', () => {
+	it('returns null without a facility', () => {
+		expect(build({ facility: null })).toBeNull();
+	});
+
+	it('builds a Place with the fueltech-specific Wikidata class', () => {
+		const place = nodeOf(build(), 'Place');
+		expect(place.additionalType).toBe(`${WIKIDATA_ENTITY}Q6558431`);
+		expect(place.name).toBe('Bayswater');
+		expect(place.geo).toEqual({
+			'@type': 'GeoCoordinates',
+			latitude: -32.39,
+			longitude: 150.95
+		});
+		expect(place.address).toEqual({
+			'@type': 'PostalAddress',
+			addressRegion: 'NSW',
+			addressCountry: 'AU'
+		});
+	});
+
+	it('falls back to the generic power station class for unmapped fueltechs', () => {
+		const place = nodeOf(
+			build({ facility: { ...facility, units: [{ fueltech_id: 'distillate' }] } }),
+			'Place'
+		);
+		expect(place.additionalType).toBe(`${WIKIDATA_ENTITY}Q159719`);
+	});
+
+	it('uses the most common unit fueltech as the primary class', () => {
+		const place = nodeOf(
+			build({
+				facility: {
+					...facility,
+					units: [
+						{ fueltech_id: 'wind' },
+						{ fueltech_id: 'wind' },
+						{ fueltech_id: 'battery_discharging' }
+					]
+				}
+			}),
+			'Place'
+		);
+		expect(place.additionalType).toBe(`${WIKIDATA_ENTITY}Q194356`);
+	});
+
+	it('collects sameAs links from the Sanity profile', () => {
+		const place = nodeOf(build(), 'Place');
+		expect(place.sameAs).toEqual([
+			'https://en.wikipedia.org/wiki/Bayswater_Power_Station',
+			`${WIKIDATA_ENTITY}Q808522`,
+			'https://www.openstreetmap.org/way/104204275',
+			'https://www.agl.com.au/'
+		]);
+	});
+
+	it('omits sameAs entirely without a Sanity profile', () => {
+		const place = nodeOf(build({ sanityFacility: null }), 'Place');
+		expect(place.sameAs).toBeUndefined();
+	});
+
+	it('rejects malformed wikidata ids and non-http links', () => {
+		const place = nodeOf(
+			build({
+				sanityFacility: { wikidata_id: 'not-a-qid', wikipedia: 'javascript:alert(1)' }
+			}),
+			'Place'
+		);
+		expect(place.sameAs).toBeUndefined();
+	});
+
+	it('sums unit capacities into a PropertyValue', () => {
+		const place = nodeOf(build(), 'Place');
+		expect(place.additionalProperty).toContainEqual({
+			'@type': 'PropertyValue',
+			name: 'Nameplate capacity',
+			value: 2640,
+			unitText: 'MW'
+		});
+		expect(place.additionalProperty).toContainEqual({
+			'@type': 'PropertyValue',
+			name: 'Fuel technology',
+			value: 'Coal (Black)'
+		});
+	});
+
+	it('survives null unit entries', () => {
+		const place = nodeOf(
+			build({ facility: { ...facility, units: [null, { fueltech_id: 'wind' }, undefined] } }),
+			'Place'
+		);
+		expect(place.additionalType).toBe(`${WIKIDATA_ENTITY}Q194356`);
+	});
+
+	it('falls back to the Sanity location when the OE one is malformed', () => {
+		const place = nodeOf(
+			build({
+				facility: { ...facility, location: { lat: null, lng: null } },
+				sanityFacility: { ...sanityFacility, location: { lat: -33.8, lng: 151.2 } }
+			}),
+			'Place'
+		);
+		expect(place.geo).toEqual({
+			'@type': 'GeoCoordinates',
+			latitude: -33.8,
+			longitude: 151.2
+		});
+	});
+
+	it('omits geo entirely when no usable location exists', () => {
+		const place = nodeOf(
+			build({ facility: { ...facility, location: null }, sanityFacility: null }),
+			'Place'
+		);
+		expect(place.geo).toBeUndefined();
+	});
+
+	it('maps WEM to WA', () => {
+		const place = nodeOf(build({ facility: { ...facility, network_region: 'WEM' } }), 'Place');
+		expect(place.address.addressRegion).toBe('WA');
+	});
+
+	it('includes a breadcrumb trail ending at the facility', () => {
+		const crumbs = nodeOf(build(), 'BreadcrumbList');
+		expect(crumbs.itemListElement).toHaveLength(3);
+		expect(crumbs.itemListElement[2]).toEqual({
+			'@type': 'ListItem',
+			position: 3,
+			name: 'Bayswater',
+			item: URL
+		});
+	});
+});
+
+describe('jsonLdToString', () => {
+	it('escapes < so content cannot close the script tag', () => {
+		const out = jsonLdToString({ description: 'bad </script><script>alert(1)</script>' });
+		expect(out).not.toContain('</script>');
+		expect(out).toContain('\\u003c/script>');
+	});
+});

--- a/src/lib/seo/jsonld.js
+++ b/src/lib/seo/jsonld.js
@@ -1,9 +1,9 @@
 /**
  * Stringify a JSON-LD object for embedding in a
- * `<script type="application/ld+json">` tag (see Meta.svelte's jsonLd prop).
- * `<` is escaped so payload content can never close the script tag early
- * (defends the {@html} injection point against e.g. a "</script>" sequence
- * in a CMS-sourced description).
+ * `<script type="application/ld+json">` tag — called by Meta.svelte on its
+ * `jsonLd` prop, the single {@html} injection point. `<` is escaped so payload
+ * content can never close the script tag early (defends against e.g. a
+ * "</script>" sequence in a CMS-sourced description).
  * @param {object} jsonLd
  * @returns {string}
  */

--- a/src/lib/seo/jsonld.js
+++ b/src/lib/seo/jsonld.js
@@ -1,0 +1,12 @@
+/**
+ * Stringify a JSON-LD object for embedding in a
+ * `<script type="application/ld+json">` tag (see Meta.svelte's jsonLd prop).
+ * `<` is escaped so payload content can never close the script tag early
+ * (defends the {@html} injection point against e.g. a "</script>" sequence
+ * in a CMS-sourced description).
+ * @param {object} jsonLd
+ * @returns {string}
+ */
+export function jsonLdToString(jsonLd) {
+	return JSON.stringify(jsonLd).replace(/</g, '\\u003c');
+}

--- a/src/lib/seo/jsonld.test.js
+++ b/src/lib/seo/jsonld.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { jsonLdToString } from './jsonld.js';
+
+describe('jsonLdToString', () => {
+	it('escapes < so content cannot close the script tag, without corrupting the data', () => {
+		const jsonLd = { description: 'bad </script><script>alert(1)</script>' };
+		const out = jsonLdToString(jsonLd);
+		expect(out).not.toContain('</script>');
+		expect(out).toContain('\\u003c/script>');
+		expect(JSON.parse(out)).toEqual(jsonLd);
+	});
+});

--- a/src/lib/utils/fueltech-display.js
+++ b/src/lib/utils/fueltech-display.js
@@ -29,18 +29,18 @@ export function getFueltechColor(fueltech) {
 }
 
 /**
- * Colour of a facility's most common unit fuel-tech — used to tint map markers
- * and footprints. Falls back to white when no fuel-tech is present.
- * @param {Array<{ fueltech_id?: string }>} [units]
- * @returns {string}
+ * A facility's most common unit fuel-tech id — the single definition of
+ * "primary" shared by map marker tints and the facility JSON-LD.
+ * @param {Array<{ fueltech_id?: string } | null | undefined>} [units]
+ * @returns {string | null}
  */
-export function primaryFuelTechColour(units) {
+export function primaryFuelTech(units) {
 	/** @type {Record<string, number>} */
 	const counts = {};
 	for (const unit of units ?? []) {
-		if (unit.fueltech_id) counts[unit.fueltech_id] = (counts[unit.fueltech_id] || 0) + 1;
+		if (unit?.fueltech_id) counts[unit.fueltech_id] = (counts[unit.fueltech_id] || 0) + 1;
 	}
-	let maxFt = '';
+	let maxFt = null;
 	let maxCount = 0;
 	for (const [ft, count] of Object.entries(counts)) {
 		if (count > maxCount) {
@@ -48,5 +48,16 @@ export function primaryFuelTechColour(units) {
 			maxFt = ft;
 		}
 	}
-	return maxFt ? getFueltechColor(maxFt) : '#ffffff';
+	return maxFt;
+}
+
+/**
+ * Colour of a facility's most common unit fuel-tech — used to tint map markers
+ * and footprints. Falls back to white when no fuel-tech is present.
+ * @param {Array<{ fueltech_id?: string }>} [units]
+ * @returns {string}
+ */
+export function primaryFuelTechColour(units) {
+	const ft = primaryFuelTech(units);
+	return ft ? getFueltechColor(ft) : '#ffffff';
 }

--- a/src/routes/(main)/facility/[code]/+page.server.js
+++ b/src/routes/(main)/facility/[code]/+page.server.js
@@ -5,7 +5,7 @@ import { fetchFacilityByCode } from '$lib/server/opennem/fetch-facility-by-code.
 import { retiredAnchorMs } from '$lib/components/charts/facility/data-end.js';
 import { sumUnitCapacities } from '$lib/utils/capacity';
 import { CHARTS_FRACTION_DEFAULT } from './_utils/charts-fraction.js';
-import { facilityJsonLdString } from '$lib/seo/facility-jsonld.js';
+import { buildFacilityJsonLd } from '$lib/seo/facility-jsonld.js';
 import facilityCardCodes from '$lib/server/og/facility-card-codes.json';
 
 const DEFAULT_RANGE_DAYS = 3;
@@ -114,7 +114,7 @@ export async function load({ params, setHeaders }) {
 		rangeDays: DEFAULT_RANGE_DAYS,
 		ogImage,
 		ogDescription,
-		schemaJsonLd: facilityJsonLdString({
+		schemaJsonLd: buildFacilityJsonLd({
 			facility,
 			sanityFacility,
 			url: `${SITE}/facility/${code}`,

--- a/src/routes/(main)/facility/[code]/+page.server.js
+++ b/src/routes/(main)/facility/[code]/+page.server.js
@@ -5,6 +5,7 @@ import { fetchFacilityByCode } from '$lib/server/opennem/fetch-facility-by-code.
 import { retiredAnchorMs } from '$lib/components/charts/facility/data-end.js';
 import { sumUnitCapacities } from '$lib/utils/capacity';
 import { CHARTS_FRACTION_DEFAULT } from './_utils/charts-fraction.js';
+import { facilityJsonLdString } from '$lib/seo/facility-jsonld.js';
 import facilityCardCodes from '$lib/server/og/facility-card-codes.json';
 
 const DEFAULT_RANGE_DAYS = 3;
@@ -102,14 +103,24 @@ export async function load({ params, setHeaders }) {
 	// prerendered behaviour while keeping the build fast.
 	setHeaders({ 'cache-control': 'public, max-age=3600' });
 
+	const ogImage = FACILITY_CARD_CODES.has(code) ? `${OG_IMAGE_BASE}/${code}.jpg` : DEFAULT_OG_IMAGE;
+	const ogDescription = buildOgDescription(facility, sanityFacility);
+
 	return {
 		facility,
 		sanityFacility,
 		timeZone,
 		retiredEndMs: computeRetiredEndMs(facility),
 		rangeDays: DEFAULT_RANGE_DAYS,
-		ogImage: FACILITY_CARD_CODES.has(code) ? `${OG_IMAGE_BASE}/${code}.jpg` : DEFAULT_OG_IMAGE,
-		ogDescription: buildOgDescription(facility, sanityFacility),
+		ogImage,
+		ogDescription,
+		schemaJsonLd: facilityJsonLdString({
+			facility,
+			sanityFacility,
+			url: `${SITE}/facility/${code}`,
+			image: ogImage,
+			description: ogDescription
+		}),
 		// Split width is restored client-side from the cookie; the chart self-fetches
 		// its series on mount.
 		chartsFraction: CHARTS_FRACTION_DEFAULT,

--- a/src/routes/(main)/facility/[code]/+page.svelte
+++ b/src/routes/(main)/facility/[code]/+page.svelte
@@ -461,6 +461,7 @@
 	imageHeight={OG_CARD_HEIGHT}
 	imageType={OG_CARD_TYPE}
 	path={`/facility/${data.facility?.code ?? ''}`}
+	jsonLd={data.schemaJsonLd}
 />
 
 <!-- Morph target — pairs with the /facilities detail panel


### PR DESCRIPTION
adds schema.org json-ld to facility pages. schema.org has no power station type so each page emits a `Place` with `additionalType` pointing at the wikidata class for the facility's primary fuel tech (coal-fired, wind farm, photovoltaic, battery storage etc, all QIDs verified against wikidata), plus:

- geo coordinates and state address
- `sameAs` links to wikipedia, wikidata entity, OSM way and operator site (from sanity)
- nameplate capacity and fuel technology as `PropertyValue`
- a `BreadcrumbList`

built server-side in the page load so the ssr payload stays identity-only and edge-cacheable. the json is pre-escaped so cms content can't close the script tag early, and `Meta.svelte` gains an optional `jsonLd` prop as the single injection point so future pages can add structured data without repeating the svelte parser workaround.

example output on /facility/BAYSW:

```json
{"@context":"https://schema.org","@graph":[{"@type":"Place","@id":"https://openelectricity.org.au/facility/BAYSW#place","additionalType":"http://www.wikidata.org/entity/Q6558431","name":"Bayswater","geo":{"@type":"GeoCoordinates","latitude":-32.394981,"longitude":150.94949},"address":{"@type":"PostalAddress","addressRegion":"NSW","addressCountry":"AU"},"sameAs":["https://en.wikipedia.org/wiki/Bayswater_Power_Station","http://www.wikidata.org/entity/Q2944653","https://www.openstreetmap.org/way/171863884"],"additionalProperty":[{"@type":"PropertyValue","name":"Nameplate capacity","value":2715,"unitText":"MW"}]}]}
```

no rich results from this (google has no power station result type) - the value is entity disambiguation and knowledge graph association.

first of a few seo pieces, robots.txt and sitemap coming as separate prs.