### PR TITLE
Drop the GWh compensator (LOCKSTEP with backend opennem#606 prod deploy)

### DIFF
--- a/src/lib/oe-api/transform.js
+++ b/src/lib/oe-api/transform.js
@@ -9,27 +9,6 @@ const unitConversions = {
 };
 
 /**
- * Market metrics whose response payload is actually in GWh even though the OE
- * API metadata reports `unit: "MWh"`. Verified by inspecting the raw API
- * response — values for these metrics are ~1000× smaller than the data-endpoint
- * fueltech energy values they should match in scale. Skipping the MWh→GWh
- * divisor for these prevents double-conversion.
- *
- * @type {Set<string>}
- */
-const METRICS_RETURNED_AS_GWH = new Set([
-	'demand_gross_energy',
-	'demand_energy',
-	'generation_renewable_energy',
-	'generation_renewable_with_storage_energy',
-	'curtailment_energy',
-	'curtailment_solar_utility_energy',
-	'curtailment_wind_energy',
-	'flow_imports_energy',
-	'flow_exports_energy'
-]);
-
-/**
  * Transform OE API INetworkTimeSeries response into StatsData[] format
  * that the processing pipeline expects.
  *
@@ -38,8 +17,7 @@ const METRICS_RETURNED_AS_GWH = new Set([
  */
 export function transformOeToStatsData(oeTimeSeries) {
 	const { metric, unit, network_code } = oeTimeSeries;
-	const isMislabeledGwh = unit === 'MWh' && METRICS_RETURNED_AS_GWH.has(metric);
-	const conversion = isMislabeledGwh ? { divisor: 1, unit: 'GWh' } : unitConversions[unit];
+	const conversion = unitConversions[unit];
 	const divisor = conversion?.divisor ?? 1;
 	const outputUnit = conversion?.unit ?? unit;
 

--- a/src/lib/oe-api/transform.test.js
+++ b/src/lib/oe-api/transform.test.js
@@ -115,10 +115,10 @@ describe('transformOeToStatsData', () => {
 		expect(result[0].history.last).toBe('');
 	});
 
-	it('does NOT divide by 1000 for market metrics that come back already in GWh', () => {
-		// The OE API mislabels these metrics: the response says unit=MWh but the
-		// actual values are GWh. Without this guard, the pipeline divides them by
-		// 1000 a second time and the percentage downstream blows up.
+	it('divides market energy metrics by 1000 like every other MWh series', () => {
+		// The market_summary energy columns used to come back 1000× low (GWh
+		// values labelled MWh) and were special-cased here. opennem#605 fixed the
+		// backend, so they now take the plain MWh→GWh path with everything else.
 		/** @type {import('openelectricity').INetworkTimeSeries} */
 		const demand = {
 			...mockEnergyTimeSeries,
@@ -131,8 +131,8 @@ describe('transformOeToStatsData', () => {
 					date_end: '2024-02-01T00:00:00+10:00',
 					columns: {},
 					data: [
-						['2024-01-01T00:00:00+10:00', 16260.146],
-						['2024-02-01T00:00:00+10:00', 15648.4243]
+						['2024-01-01T00:00:00+10:00', 16260146],
+						['2024-02-01T00:00:00+10:00', 15648424.3]
 					]
 				}
 			]
@@ -140,11 +140,10 @@ describe('transformOeToStatsData', () => {
 
 		const result = transformOeToStatsData(demand);
 		expect(result[0].units).toBe('GWh');
-		// values pass through unchanged (no /1000)
 		expect(result[0].history.data).toEqual([16260.146, 15648.4243]);
 	});
 
-	it('does NOT divide by 1000 for generation_renewable_energy market metric', () => {
+	it('divides generation_renewable_energy by 1000', () => {
 		/** @type {import('openelectricity').INetworkTimeSeries} */
 		const renewable = {
 			...mockEnergyTimeSeries,
@@ -156,7 +155,7 @@ describe('transformOeToStatsData', () => {
 					date_start: '2024-01-01T00:00:00+10:00',
 					date_end: '2024-01-01T00:00:00+10:00',
 					columns: {},
-					data: [['2024-01-01T00:00:00+10:00', 4868.8033]]
+					data: [['2024-01-01T00:00:00+10:00', 4868803.3]]
 				}
 			]
 		};
@@ -164,6 +163,29 @@ describe('transformOeToStatsData', () => {
 		const result = transformOeToStatsData(renewable);
 		expect(result[0].units).toBe('GWh');
 		expect(result[0].history.data).toEqual([4868.8033]);
+	});
+
+	it('divides flow energy metrics by 1000', () => {
+		// These were never 1000× off upstream — they always returned true MWh.
+		/** @type {import('openelectricity').INetworkTimeSeries} */
+		const flows = {
+			...mockEnergyTimeSeries,
+			metric: /** @type {any} */ ('flow_imports_energy'),
+			unit: 'MWh',
+			results: [
+				{
+					name: 'flow_imports_energy_total',
+					date_start: '2024-01-01T00:00:00+10:00',
+					date_end: '2024-01-01T00:00:00+10:00',
+					columns: {},
+					data: [['2024-01-01T00:00:00+10:00', 250000]]
+				}
+			]
+		};
+
+		const result = transformOeToStatsData(flows);
+		expect(result[0].units).toBe('GWh');
+		expect(result[0].history.data).toEqual([250]);
 	});
 
 	it('still divides fueltech energy (genuine MWh) by 1000', () => {


### PR DESCRIPTION
do not merge on its own. this has to land at the same time as the backend fix in opennem/opennem#606 hits **prod** and the clickhouse backfill has run. see opennem/opennem#605.

## what this is

the backend stored seven `market_summary` energy columns 1000x low (GWh values labelled MWh). the frontend has been cancelling that out in `src/lib/oe-api/transform.js`: a `METRICS_RETURNED_AS_GWH` set that skipped the MWh -> GWh divisor and relabelled the output GWh.

opennem#606 makes those metrics return true MWh, so the compensator has to go. this pr removes the set and the `isMislabeledGwh` branch, and every MWh series now takes the same `/1000` path as the fueltech energy endpoint.

## why the timing matters

- **merged before the backend is on prod**: api still returns GWh-scale values, we now divide by 1000 anyway, renewables numbers come out **1000x low**. homepage fossil-fuels-renewables infographic and /studio/renewables both break.
- **backend ships to prod without this**: api returns true MWh, we skip the divisor, renewables numbers come out **1000x high**. same two pages.

so: merge + deploy this only once #606 is live on prod and backfilled.

## net effect once both sides are in

identical output. today the compensated path takes a GWh-scale number and passes it through labelled GWh. after both changes the same series arrives 1000x larger in true MWh and gets divided by 1000, landing on the same GWh value. live consumers (`fetch-renewables.server.js` -> `calculate-renewables.js`) see no change in scale or unit label.

## also removed: the flow metrics

`flow_imports_energy` and `flow_exports_energy` were in the set but were **never** 1000x off upstream, the backend always returned true MWh for them. that entry was latent and wrong today: anything routing flow energy through `transformOeToStatsData` would have had true MWh relabelled as GWh. nothing does today (the flows charts read the raw api response), but it's gone now either way, with a test covering it.

## note on the network charts

`NetworkChart` / `market-metrics.js` (demand_energy, curtailment_*_energy, flows_energy) never went through this transform. they render the raw api response and label `_energy` metrics MWh with no conversion, so the mislabelled metrics have been reading 1000x low there. those self-heal when #606 lands. no frontend change needed, just don't be surprised when the numbers jump.

## tests

`pnpm run test` -> 131 files, 1916 tests, all passing. the two compensator tests in `transform.test.js` now assert the plain divisor path with fixtures restated in true MWh (so the expected GWh output is unchanged from before), plus a new `flow_imports_energy` case.