### PR TITLE
allow mobile zoom

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -278,13 +278,17 @@
 		font-weight: 600;
 	}
 
-	/* Mobile zoom lock. iOS Safari ignores maximum-scale/user-scalable in the
-	   viewport meta for pinch and double-tap gestures, so this is what actually
-	   blocks them there (the meta covers Android and installed PWAs). Map and
+	/* iOS zoom lock. iOS Safari ignores maximum-scale/user-scalable in the
+	   viewport meta for pinch and double-tap gestures, so this is what blocks
+	   them there. Scoped to iOS via the -webkit-touch-callout support check —
+	   unscoped, touch-action: pan-x pan-y also disables pinch zoom in Chrome
+	   for Android, which should follow the (permissive) viewport meta. Map and
 	   chart gestures are JS-driven on their own elements and are unaffected. */
 	@media (max-width: 767px) {
-		html {
-			touch-action: pan-x pan-y;
+		@supports (-webkit-touch-callout: none) {
+			html {
+				touch-action: pan-x pan-y;
+			}
 		}
 	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -35,10 +35,7 @@
 			type="font/ttf"
 			crossorigin
 		/>
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-		/>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
drops `maximum-scale=1, user-scalable=no` from the viewport meta. disabling zoom fails WCAG 1.4.4 and the squirrel audit flags it as an error on all 67 pages (a11y/zoom-disabled + mobile/viewport-zoom) - it's the single biggest scorer in the audit.

second commit (from codex review): the css `touch-action: pan-x pan-y` lock from #107 turns out to disable pinch zoom in chrome for android too, not just iOS - so dropping the meta alone didn't actually restore zoom on android. the rule is now scoped to iOS via `@supports (-webkit-touch-callout: none)`, so android and PWAs follow the (now permissive) meta.

@steven heads up: iOS pinch behaviour is unchanged - the #107 zoom lock still applies there, just scoped so it only hits iOS. if you're happy for pinch zoom to come back on iOS too we can drop the css block in a follow-up - the audit can't see it but it's the same accessibility issue.
