### PR TITLE
robots.txt and xml sitemaps

### DIFF
--- a/src/lib/seo/sitemap.js
+++ b/src/lib/seo/sitemap.js
@@ -1,0 +1,59 @@
+/**
+ * XML sitemap builders (sitemaps.org protocol) for the /sitemap*.xml routes.
+ * Kept free of route imports so helpers are unit-testable. Routes pass their
+ * request's `url.origin` — hardcoding the prod domain would emit cross-host
+ * (invalid) entries on dev/preview deployments.
+ */
+
+import { escapeXml } from './xml.js';
+
+/**
+ * `<urlset>` document for a list of pages.
+ * @param {Array<{ loc: string, lastmod?: string | null }>} entries
+ * @returns {string}
+ */
+export function urlsetXml(entries) {
+	const urls = entries
+		.map(({ loc, lastmod }) => {
+			const lastmodTag = lastmod ? `<lastmod>${escapeXml(lastmod)}</lastmod>` : '';
+			return `<url><loc>${escapeXml(loc)}</loc>${lastmodTag}</url>`;
+		})
+		.join('\n');
+	return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
+}
+
+/**
+ * `<sitemapindex>` document pointing at the child sitemaps.
+ * @param {string[]} locs
+ * @returns {string}
+ */
+export function sitemapIndexXml(locs) {
+	const sitemaps = locs.map((loc) => `<sitemap><loc>${escapeXml(loc)}</loc></sitemap>`).join('\n');
+	return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${sitemaps}\n</sitemapindex>`;
+}
+
+/**
+ * XML response with edge caching, matching the facility pages' 1h policy.
+ * @param {string} body
+ * @returns {Response}
+ */
+export function xmlResponse(body) {
+	return new Response(body, {
+		headers: {
+			'content-type': 'application/xml; charset=utf-8',
+			'cache-control': 'public, max-age=3600'
+		}
+	});
+}
+
+/**
+ * `_updatedAt`-style timestamp → sitemap lastmod date (YYYY-MM-DD), or null
+ * when unparseable.
+ * @param {string | null | undefined} timestamp
+ * @returns {string | null}
+ */
+export function toLastmod(timestamp) {
+	if (!timestamp) return null;
+	const match = String(timestamp).match(/^\d{4}-\d{2}-\d{2}/);
+	return match ? match[0] : null;
+}

--- a/src/lib/seo/sitemap.test.js
+++ b/src/lib/seo/sitemap.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { sitemapIndexXml, toLastmod, urlsetXml, xmlResponse } from './sitemap.js';
+
+describe('urlsetXml', () => {
+	it('builds a urlset with optional lastmod', () => {
+		const xml = urlsetXml([
+			{ loc: 'https://example.com/a', lastmod: '2026-08-04' },
+			{ loc: 'https://example.com/b' }
+		]);
+		expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+		expect(xml).toContain(
+			'<url><loc>https://example.com/a</loc><lastmod>2026-08-04</lastmod></url>'
+		);
+		expect(xml).toContain('<url><loc>https://example.com/b</loc></url>');
+	});
+
+	it('escapes XML special characters in locs', () => {
+		const xml = urlsetXml([{ loc: 'https://example.com/?a=1&b=<2>' }]);
+		expect(xml).toContain('https://example.com/?a=1&amp;b=&lt;2&gt;');
+		expect(xml).not.toContain('&b=<');
+	});
+});
+
+describe('sitemapIndexXml', () => {
+	it('builds a sitemapindex with escaped locs', () => {
+		const xml = sitemapIndexXml(['https://example.com/sitemap-a.xml?x=1&y=2']);
+		expect(xml).toContain('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+		expect(xml).toContain(
+			'<sitemap><loc>https://example.com/sitemap-a.xml?x=1&amp;y=2</loc></sitemap>'
+		);
+	});
+});
+
+describe('xmlResponse', () => {
+	it('sets the XML content type and edge cache policy', () => {
+		const res = xmlResponse('<x/>');
+		expect(res.headers.get('content-type')).toBe('application/xml; charset=utf-8');
+		expect(res.headers.get('cache-control')).toBe('public, max-age=3600');
+	});
+});
+
+describe('toLastmod', () => {
+	it('trims Sanity timestamps to a date', () => {
+		expect(toLastmod('2026-07-30T02:15:00Z')).toBe('2026-07-30');
+	});
+
+	it('returns null for missing or malformed input', () => {
+		expect(toLastmod(null)).toBeNull();
+		expect(toLastmod('not a date')).toBeNull();
+	});
+});

--- a/src/lib/seo/xml.js
+++ b/src/lib/seo/xml.js
@@ -1,0 +1,10 @@
+/** @type {Record<string, string>} */
+const XML_ENTITIES = { '<': '&lt;', '>': '&gt;', '&': '&amp;', "'": '&apos;', '"': '&quot;' };
+
+/**
+ * Escape a string for safe inclusion in XML text/attribute content.
+ * @param {string} str
+ */
+export function escapeXml(str) {
+	return str.replace(/[<>&'"]/g, (c) => XML_ENTITIES[c]);
+}

--- a/src/lib/server/opennem/fetch-facilities.js
+++ b/src/lib/server/opennem/fetch-facilities.js
@@ -4,13 +4,13 @@ import { PUBLIC_OE_API_KEY, PUBLIC_OE_API_URL } from '$env/static/public';
  * Fetch the full facility list via the raw OE API — no filters, so every
  * status (operating, committed, retired) is included. Companion to
  * fetch-facility-by-code.js; keeps the URL/auth shape in one place.
- * @returns {Promise<any[] | null>} null on upstream failure
+ * @returns {Promise<any[] | null>} null on upstream failure or a malformed body
  */
 export async function fetchAllFacilities() {
-	const res = await fetch(`${PUBLIC_OE_API_URL}/facilities/`, {
+	const json = await fetch(`${PUBLIC_OE_API_URL}/facilities/`, {
 		headers: { Authorization: `Bearer ${PUBLIC_OE_API_KEY}` }
-	}).catch(() => null);
-	if (!res?.ok) return null;
-	const json = await res.json();
-	return Array.isArray(json.data) ? json.data : [];
+	})
+		.then((res) => (res.ok ? res.json() : null))
+		.catch(() => null);
+	return Array.isArray(json?.data) ? json.data : null;
 }

--- a/src/lib/server/opennem/fetch-facilities.js
+++ b/src/lib/server/opennem/fetch-facilities.js
@@ -1,0 +1,16 @@
+import { PUBLIC_OE_API_KEY, PUBLIC_OE_API_URL } from '$env/static/public';
+
+/**
+ * Fetch the full facility list via the raw OE API — no filters, so every
+ * status (operating, committed, retired) is included. Companion to
+ * fetch-facility-by-code.js; keeps the URL/auth shape in one place.
+ * @returns {Promise<any[] | null>} null on upstream failure
+ */
+export async function fetchAllFacilities() {
+	const res = await fetch(`${PUBLIC_OE_API_URL}/facilities/`, {
+		headers: { Authorization: `Bearer ${PUBLIC_OE_API_KEY}` }
+	}).catch(() => null);
+	if (!res?.ok) return null;
+	const json = await res.json();
+	return Array.isArray(json.data) ? json.data : [];
+}

--- a/src/routes/(main)/records/rss.xml/feed.js
+++ b/src/routes/(main)/records/rss.xml/feed.js
@@ -1,4 +1,5 @@
 import { parseISO } from 'date-fns';
+import { escapeXml } from '$lib/seo/xml.js';
 import { stripDateTimezone } from '$lib/utils/date-format.js';
 import generateDescription from '../page-data-options/record-description.js';
 import { formatRecordValue } from '../page-data-options/formatters.js';
@@ -8,16 +9,9 @@ import { formatRecordValue } from '../page-data-options/formatters.js';
 /** Number of records the feed exposes (also the API page size). */
 export const FEED_SIZE = 100;
 
-/** @type {Record<string, string>} */
-const XML_ENTITIES = { '<': '&lt;', '>': '&gt;', '&': '&amp;', "'": '&apos;', '"': '&quot;' };
-
-/**
- * Escape a string for safe inclusion in XML text/attribute content.
- * @param {string} str
- */
-export function escapeXml(str) {
-	return str.replace(/[<>&'"]/g, (c) => XML_ENTITIES[c]);
-}
+// Re-exported so existing consumers/tests keep their import path; the
+// implementation moved to $lib/seo/xml.js when the sitemap routes needed it.
+export { escapeXml };
 
 /**
  * The OE API returns interval timestamps in the network's local time, but the

--- a/src/routes/sitemap-articles.xml/+server.js
+++ b/src/routes/sitemap-articles.xml/+server.js
@@ -1,6 +1,14 @@
-import { error } from '@sveltejs/kit';
 import { client } from '$lib/sanity';
 import { toLastmod, urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
+
+// Prerendered: the /analysis pages this sitemap lists are themselves
+// prerendered, so a runtime query would advertise articles published since
+// the last deploy — URLs that 404 until the next release. Snapshotting in
+// the same build keeps the sitemap exactly in sync with the deployed pages.
+// A Sanity outage fails the build (like the /analysis prerender itself)
+// rather than shipping without this sitemap. url.origin comes from
+// kit.prerender.origin in svelte.config.js.
+export const prerender = true;
 
 /**
  * Editorial pages from Sanity: /analysis/<slug> articles and
@@ -12,23 +20,16 @@ import { toLastmod, urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
  * for indexing either. Sanity `content` documents are deliberately absent —
  * /content/* is excluded from the Cloudflare worker and not prerendered, so
  * those URLs currently 404 in production.
- * @param {{ url: URL }} event
+ * @type {import('./$types').RequestHandler}
  */
 export async function GET({ url }) {
-	/** @type {Array<{ slug: string, _updatedAt?: string }>} */
-	let articles;
-	/** @type {Array<{ slug: string, _updatedAt?: string }>} */
-	let tags;
-	try {
-		[articles, tags] = await Promise.all([
-			client.fetch(
-				`*[_type == "article" && defined(slug.current) && defined(article_type)]{ "slug": slug.current, _updatedAt }`
-			),
-			client.fetch(`*[_type == "tag" && defined(slug.current)]{ "slug": slug.current, _updatedAt }`)
-		]);
-	} catch {
-		throw error(503, 'CMS unavailable');
-	}
+	/** @type {[Array<{ slug: string, _updatedAt?: string }>, Array<{ slug: string, _updatedAt?: string }>]} */
+	const [articles, tags] = await Promise.all([
+		client.fetch(
+			`*[_type == "article" && defined(slug.current) && defined(article_type)]{ "slug": slug.current, _updatedAt }`
+		),
+		client.fetch(`*[_type == "tag" && defined(slug.current)]{ "slug": slug.current, _updatedAt }`)
+	]);
 
 	/**
 	 * @param {Array<{ slug: string, _updatedAt?: string }>} docs

--- a/src/routes/sitemap-articles.xml/+server.js
+++ b/src/routes/sitemap-articles.xml/+server.js
@@ -1,0 +1,46 @@
+import { error } from '@sveltejs/kit';
+import { client } from '$lib/sanity';
+import { toLastmod, urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
+
+/**
+ * Editorial pages from Sanity: /analysis/<slug> articles and
+ * /analysis/tags/<slug> listings. `_updatedAt` is a trustworthy lastmod here —
+ * it moves only on publish.
+ *
+ * The article filter mirrors the /analysis listing (analysis/+page.server.js):
+ * `article_type == null` marks unlisted articles, which shouldn't be submitted
+ * for indexing either. Sanity `content` documents are deliberately absent —
+ * /content/* is excluded from the Cloudflare worker and not prerendered, so
+ * those URLs currently 404 in production.
+ * @param {{ url: URL }} event
+ */
+export async function GET({ url }) {
+	/** @type {Array<{ slug: string, _updatedAt?: string }>} */
+	let articles;
+	/** @type {Array<{ slug: string, _updatedAt?: string }>} */
+	let tags;
+	try {
+		[articles, tags] = await Promise.all([
+			client.fetch(
+				`*[_type == "article" && defined(slug.current) && defined(article_type)]{ "slug": slug.current, _updatedAt }`
+			),
+			client.fetch(`*[_type == "tag" && defined(slug.current)]{ "slug": slug.current, _updatedAt }`)
+		]);
+	} catch {
+		throw error(503, 'CMS unavailable');
+	}
+
+	/**
+	 * @param {Array<{ slug: string, _updatedAt?: string }>} docs
+	 * @param {string} prefix
+	 */
+	const entries = (docs, prefix) =>
+		docs.map((d) => ({
+			loc: `${url.origin}${prefix}/${encodeURIComponent(d.slug)}`,
+			lastmod: toLastmod(d._updatedAt)
+		}));
+
+	return xmlResponse(
+		urlsetXml([...entries(articles, '/analysis'), ...entries(tags, '/analysis/tags')])
+	);
+}

--- a/src/routes/sitemap-facilities.xml/+server.js
+++ b/src/routes/sitemap-facilities.xml/+server.js
@@ -1,0 +1,28 @@
+import { error } from '@sveltejs/kit';
+import { fetchAllFacilities } from '$lib/server/opennem/fetch-facilities.js';
+import { urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
+
+/**
+ * One entry per facility page (~600), every status — retired facilities have
+ * pages too. 503 on upstream failure rather than serving an empty urlset: a
+ * transient empty sitemap risks deindexing every facility page until the
+ * next crawl.
+ * @param {{ url: URL }} event
+ */
+export async function GET({ url }) {
+	const facilities = await fetchAllFacilities();
+	if (!facilities) throw error(503, 'Facilities unavailable');
+
+	const codes = facilities
+		.map((/** @type {any} */ f) => f?.code)
+		.filter(Boolean)
+		.sort();
+
+	return xmlResponse(
+		urlsetXml(
+			codes.map((/** @type {string} */ code) => ({
+				loc: `${url.origin}/facility/${encodeURIComponent(code)}`
+			}))
+		)
+	);
+}

--- a/src/routes/sitemap-facilities.xml/+server.js
+++ b/src/routes/sitemap-facilities.xml/+server.js
@@ -7,7 +7,7 @@ import { urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
  * pages too. 503 on upstream failure rather than serving an empty urlset: a
  * transient empty sitemap risks deindexing every facility page until the
  * next crawl.
- * @param {{ url: URL }} event
+ * @type {import('./$types').RequestHandler}
  */
 export async function GET({ url }) {
 	const facilities = await fetchAllFacilities();

--- a/src/routes/sitemap-static.xml/+server.js
+++ b/src/routes/sitemap-static.xml/+server.js
@@ -4,10 +4,11 @@ import { urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
 // (/studio, /records-checker, the (micro) embeds) are deliberately absent and
 // disallowed in robots.txt. Individual records pages are also left out for
 // now — thousands of thin, query-param-heavy pages would drown the rest.
+// /tracker is absent while it's alpha (nav-gated behind the tracker_nav
+// flag) — add it here when it launches.
 const STATIC_PATHS = [
 	'/',
 	'/facilities',
-	'/tracker',
 	'/records',
 	'/scenarios',
 	'/analysis',
@@ -16,7 +17,7 @@ const STATIC_PATHS = [
 	'/newsletter'
 ];
 
-/** @param {{ url: URL }} event */
+/** @type {import('./$types').RequestHandler} */
 export function GET({ url }) {
 	return xmlResponse(urlsetXml(STATIC_PATHS.map((path) => ({ loc: `${url.origin}${path}` }))));
 }

--- a/src/routes/sitemap-static.xml/+server.js
+++ b/src/routes/sitemap-static.xml/+server.js
@@ -1,0 +1,22 @@
+import { urlsetXml, xmlResponse } from '$lib/seo/sitemap.js';
+
+// Hand-curated: the indexable top-level surfaces. App-like and utility routes
+// (/studio, /records-checker, the (micro) embeds) are deliberately absent and
+// disallowed in robots.txt. Individual records pages are also left out for
+// now — thousands of thin, query-param-heavy pages would drown the rest.
+const STATIC_PATHS = [
+	'/',
+	'/facilities',
+	'/tracker',
+	'/records',
+	'/scenarios',
+	'/analysis',
+	'/strata-community',
+	'/about',
+	'/newsletter'
+];
+
+/** @param {{ url: URL }} event */
+export function GET({ url }) {
+	return xmlResponse(urlsetXml(STATIC_PATHS.map((path) => ({ loc: `${url.origin}${path}` }))));
+}

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -1,0 +1,15 @@
+import { sitemapIndexXml, xmlResponse } from '$lib/seo/sitemap.js';
+
+/**
+ * Index pointing at the child sitemaps (referenced from static/robots.txt).
+ * @param {{ url: URL }} event
+ */
+export function GET({ url }) {
+	return xmlResponse(
+		sitemapIndexXml([
+			`${url.origin}/sitemap-static.xml`,
+			`${url.origin}/sitemap-facilities.xml`,
+			`${url.origin}/sitemap-articles.xml`
+		])
+	);
+}

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -2,7 +2,7 @@ import { sitemapIndexXml, xmlResponse } from '$lib/seo/sitemap.js';
 
 /**
  * Index pointing at the child sitemaps (referenced from static/robots.txt).
- * @param {{ url: URL }} event
+ * @type {import('./$types').RequestHandler}
  */
 export function GET({ url }) {
 	return xmlResponse(

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,18 @@
+# Open Electricity — openelectricity.org.au
+# All crawlers are welcome here, including AI/LLM agents (GPTBot, ClaudeBot,
+# PerplexityBot, Google-Extended, CCBot and friends). The disallowed paths are
+# app tooling and embed duplicates, not content.
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /studio
+Disallow: /article-drafts
+Disallow: /records-checker
+Disallow: /data-tracker
+Disallow: /record/
+Disallow: /strata-embed/
+Disallow: /stratify
+Disallow: /widget
+
+Sitemap: https://openelectricity.org.au/sitemap.xml

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -22,6 +22,7 @@ const config = {
 					'/og/*',
 					'/map-styles/*',
 					'/favicon.png',
+					'/robots.txt',
 					'/studio/lens-on-emissions/data/*',
 					'/analysis/*',
 					'/content/*',

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -31,7 +31,11 @@ const config = {
 			}
 		}),
 		prerender: {
-			handleHttpError: 'warn'
+			handleHttpError: 'warn',
+			// Absolute URLs emitted during prerender (e.g. /sitemap-articles.xml)
+			// resolve against the production domain instead of the default
+			// http://sveltekit-prerender placeholder.
+			origin: 'https://openelectricity.org.au'
 		},
 		version: {
 			name: pkg.version,


### PR DESCRIPTION
adds the two missing crawl fundamentals flagged by the audit (crawl/sitemap-exists was error severity, crawl/robots-txt a warning - both currently 404).

**robots.txt** (static file, served direct from cloudflare via the adapter exclude list)
- explicitly welcomes all crawlers including AI/LLM agents (GPTBot, ClaudeBot, PerplexityBot etc) - we want agent traffic
- disallows are app tooling and embed duplicates only: /api, /studio, /article-drafts, /records-checker, /data-tracker and the micro embed routes (/record, /strata-embed, /stratify, /widget)
- points at the sitemap

**sitemaps** - /sitemap.xml is an index over three children:
- `sitemap-static.xml` - hand-curated top-level surfaces (/, /facilities, /tracker, /records, /scenarios, /analysis, /strata-community, /about, /newsletter)
- `sitemap-facilities.xml` - all ~618 facility pages from the OE api, every status incl retired. 503s on upstream failure rather than serving an empty urlset (a transient outage shouldn't deindex 600 pages)
- `sitemap-articles.xml` - sanity articles + tag listings, `_updatedAt` as lastmod, filter mirrors the /analysis listing (unlisted `article_type == null` articles stay out)

urls are built from the request origin rather than a hardcoded domain so preview/dev deployments don't emit cross-host entries (invalid per sitemaps.org).

individual records pages are deliberately left out for now - thousands of thin query-param-heavy pages.

second commit (from codex review): `fetchAllFacilities` now returns null on a malformed 2xx body (missing/non-array `data`, or a body parse failure) instead of an empty list, so those cases 503 like any other upstream failure rather than serving a successful empty sitemap.

two things found along the way:
- `/content/*` pages (developers, about-the-data etc) **404 in production** - the route is excluded from the cloudflare worker in svelte.config but never prerendered. left them out of the sitemap; needs its own fix
- `escapeXml` moved from the records rss feed to `$lib/seo/xml.js` and is now shared

follow-up to #114/#116, next up is the headers pass (cache-control/hsts) and the /facilities html weight.
